### PR TITLE
add tests by updating git submodule

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -136,6 +136,7 @@ jobs:
       - name: backup case if download fails
         if: ${{ steps.download-report.outcome == 'failure' }}
         run: mkdir -p main-branch-report && cp -r ./partiql-conformance-tests/backup_conformance_report.json ./main-branch-report/cts_report.json
+      - run: ls -R .
       # Run conformance report comparison. Generates cts-comparison-report.md
       - run: ./target/debug/generate_comparison_report ./main-branch-report/cts_report.json cts_report.json cts-comparison-report.md
       # Print conformance report to GitHub actions workflow summary page

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -131,7 +131,6 @@ jobs:
         continue-on-error: true
         with:
           workflow: ci_build_test.yml
-          name: main-branch-report
           branch: main
       - name: backup case if download fails
         if: ${{ steps.download-report.outcome == 'failure' }}


### PR DESCRIPTION
Add tests to conformance tests by updating git submodule.

This differs from the previous closed PRs:
- conformance test generator was updated to handle non-parse cases
- `main` conformance test suite artifact was updated to include a name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
