### PR TITLE
Test breaking out conformance comparison report to separate job

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -127,7 +127,7 @@ jobs:
           path: ./*
           key: ${{ github.sha }}-conformance-report
   conformance-report-comparison:
-    name: Create comparison report for PRs
+    name: Create comparison report for `pull_request` event
     runs-on: ubuntu-latest
     needs: [conformance-report]
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -84,8 +84,8 @@ jobs:
           key: ${{ github.sha }}
   # Conformance report generation and comparison report generation job will run only after the `Build and Test` job
   # succeeds.
-  conformance:
-    name: Check conformance
+  conformance-report:
+    name: Create conformance report for `push` and `pull_request` events
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -118,6 +118,35 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: cts_report.json
+      # Cache the `cargo build` and conformance report for `conformance-report-comparison` job (pull_request event only)
+      - name: Cache `cargo build` and conformance report
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v2
+        id: restore-build-and-conformance
+        with:
+          path: ./*
+          key: ${{ github.sha }}-conformance-report
+  conformance-report-comparison:
+    name: Create comparison report for PRs
+    runs-on: ubuntu-latest
+    needs: [conformance-report]
+    if: github.event_name == 'pull_request'
+    steps:
+      # Pull down cached `cargo build` and conformance report
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions/cache@v2
+        id: restore-build-and-conformance
+        with:
+          path: ./*
+          key: ${{ github.sha }}-conformance-report
       # Download conformance report from `main` to create comparison report. If `main` has no report, use a backup
       # report (stored in partiql-conformance-tests/backup_conformance_report.json). Alternatively, we could consider
       # - pulling `main` branch and rerun the tests
@@ -143,7 +172,6 @@ jobs:
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: fc
-        if: github.event_name == 'pull_request'
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -159,7 +187,6 @@ jobs:
       # Create or update (if previous comment exists) with markdown version of comparison report
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v2
-        if: github.event_name == 'pull_request'
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Followup to https://github.com/alancai98/partiql-lang-rust/pull/11. Changes the GitHub Actions caching key to ensure the cached build (+ conformance report) is properly cached.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
